### PR TITLE
Hotfix: Do not dispose of the HttpClient stream in download methods

### DIFF
--- a/PixivApi/Clients/FanboxClient.cs
+++ b/PixivApi/Clients/FanboxClient.cs
@@ -339,7 +339,7 @@ public class FanboxClient : IDisposable
         var content = await _resiliencePipeline.ExecuteAsync(
             async token =>
             {
-                using var response = await _downloadHttpClient.GetAsync(fileUrl, HttpCompletionOption.ResponseHeadersRead, token);
+                var response = await _downloadHttpClient.GetAsync(fileUrl, HttpCompletionOption.ResponseHeadersRead, token);
                 var content = await response.Content.ReadAsStreamAsync(token);
                 return content;
             }, cancellationToken);

--- a/PixivApi/Clients/PixivClient.cs
+++ b/PixivApi/Clients/PixivClient.cs
@@ -631,7 +631,7 @@ public class PixivClient : IDisposable
     {
         return await _resiliencePipeline.ExecuteAsync(async token =>
         {
-            using var response = await _downloadHttpClient.GetAsync(illustUrl, token);
+            var response = await _downloadHttpClient.GetAsync(illustUrl, token);
             var content = await response.Content.ReadAsStreamAsync(token);
         
             return content;


### PR DESCRIPTION
Calling `using` on `HttpResponseMessage` disposed the returned stream. Now the stream is no longer disposed unless the user provides a stream to the download functions, in which case the `HttpResponseMessage` stream is being streamed to the one provided by the user and can be safely disposed within the download method.