### PR TITLE
hotfix: wrap Fanbox post pagination and post list API responses

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ permissions:
 env:
   MAJOR: 4
   MINOR: 0
-  PATCH: 0
+  PATCH: 1
 
 jobs:
   build:

--- a/PixivApi.Tests/Payloads/Fanbox/GetCreatorPostPagination.json
+++ b/PixivApi.Tests/Payloads/Fanbox/GetCreatorPostPagination.json
@@ -1,5 +1,6 @@
 {
-  "body": [
+  "body": {
+    "pageUrls": [
     "https:\/\/api.fanbox.cc\/post.listCreator?creatorId=emorimiku\u0026maxPublishedDatetime=2025-05-03%2015%3A01%3A05\u0026maxId=9820948\u0026limit=10",
     "https:\/\/api.fanbox.cc\/post.listCreator?creatorId=emorimiku\u0026maxPublishedDatetime=2025-02-08%2012%3A00%3A00\u0026maxId=9345840\u0026limit=10",
     "https:\/\/api.fanbox.cc\/post.listCreator?creatorId=emorimiku\u0026maxPublishedDatetime=2024-12-28%2023%3A07%3A32\u0026maxId=9112117\u0026limit=10",
@@ -88,5 +89,6 @@
     "https:\/\/api.fanbox.cc\/post.listCreator?creatorId=emorimiku\u0026maxPublishedDatetime=2019-08-08%2011%3A55%3A51\u0026maxId=502253\u0026limit=10",
     "https:\/\/api.fanbox.cc\/post.listCreator?creatorId=emorimiku\u0026maxPublishedDatetime=2019-07-15%2023%3A27%3A25\u0026maxId=469653\u0026limit=10",
     "https:\/\/api.fanbox.cc\/post.listCreator?creatorId=emorimiku\u0026maxPublishedDatetime=2019-07-01%2015%3A35%3A15\u0026maxId=449470\u0026limit=10"
-  ]
+    ]
+  }
 }

--- a/PixivApi.Tests/Payloads/Fanbox/GetCreatorPostsFromPagination.json
+++ b/PixivApi.Tests/Payloads/Fanbox/GetCreatorPostsFromPagination.json
@@ -1,5 +1,6 @@
 {
-  "body": [
+  "body": {
+    "posts": [
     {
       "id": "9820948",
       "title": "\u30b5\u30a4\u30f3\u4f1a\u90f5\u9001\u5206",
@@ -260,5 +261,6 @@
       "excerpt": "",
       "isPinned": false
     }
-  ]
+    ]
+  }
 }

--- a/PixivApi/Clients/FanboxClient.cs
+++ b/PixivApi/Clients/FanboxClient.cs
@@ -248,8 +248,8 @@ public class FanboxClient : IDisposable
     public async Task<string[]> GetCreatorPostPaginationAsync(string creatorId, CancellationToken cancellationToken = default)
     {
         var url = $"post.paginateCreator?creatorId={creatorId}";
-        var response = await CommonGetAsync(url, FanboxJsonSerializerContext.Default.FanboxResponseWrapperStringArray, cancellationToken);
-        return response;
+        var response = await CommonGetAsync(url, FanboxJsonSerializerContext.Default.FanboxResponseWrapperPostPaginationResponse, cancellationToken);
+        return response.PageUrls;
     }
 
     /// <summary>
@@ -261,8 +261,8 @@ public class FanboxClient : IDisposable
     public async Task<PostListItem[]> GetCreatorPostsFromPaginationAsync(string paginationUrl, CancellationToken cancellationToken = default)
     {
         var url = paginationUrl.Replace(BaseUriHttps, "");
-        var response = await CommonGetAsync(url, FanboxJsonSerializerContext.Default.FanboxResponseWrapperPostListItemArray, cancellationToken);
-        return response;
+        var response = await CommonGetAsync(url, FanboxJsonSerializerContext.Default.FanboxResponseWrapperPostListResponse, cancellationToken);
+        return response.Posts;
     }
     
 

--- a/PixivApi/Models/Fanbox/PostListResponse.cs
+++ b/PixivApi/Models/Fanbox/PostListResponse.cs
@@ -1,0 +1,10 @@
+namespace Scighost.PixivApi.Models.Fanbox;
+
+/// <summary>
+/// Wrapper for the post list response
+/// </summary>
+/// <param name="Posts">Array of post list items</param>
+public record PostListResponse(
+    [property: JsonPropertyName("posts")]
+    PostListItem[] Posts
+);

--- a/PixivApi/Models/Fanbox/PostPaginationResponse.cs
+++ b/PixivApi/Models/Fanbox/PostPaginationResponse.cs
@@ -1,0 +1,10 @@
+namespace Scighost.PixivApi.Models.Fanbox;
+
+/// <summary>
+/// Wrapper for the post pagination response
+/// </summary>
+/// <param name="PageUrls">Array of paginated post listing URLs</param>
+public record PostPaginationResponse(
+    [property: JsonPropertyName("pageUrls")]
+    string[] PageUrls
+);

--- a/PixivApi/SerializerContexts/FanboxJsonSerializerContext.cs
+++ b/PixivApi/SerializerContexts/FanboxJsonSerializerContext.cs
@@ -9,10 +9,10 @@ namespace Scighost.PixivApi.SerializerContexts;
 /// 
 /// </summary>
 [JsonSerializable(typeof(object))]
-[JsonSerializable(typeof(FanboxResponseWrapper<string[]>))]
+[JsonSerializable(typeof(FanboxResponseWrapper<PostPaginationResponse>))]
 [JsonSerializable(typeof(FanboxResponseWrapper<CreatorPlansResponse>))]
 [JsonSerializable(typeof(FanboxResponseWrapper<FollowedCreatorsResponse>))]
-[JsonSerializable(typeof(FanboxResponseWrapper<PostListItem[]>))]
+[JsonSerializable(typeof(FanboxResponseWrapper<PostListResponse>))]
 [JsonSerializable(typeof(FanboxResponseWrapper<PostInfoResponse>))]
 [JsonSerializable(typeof(FanboxResponseWrapper<CreatorSearchResult>))]
 [JsonSerializable(typeof(FanboxResponseWrapper<SearchRecommendCreatorsResult>))]


### PR DESCRIPTION
- Add PostPaginationResponse model wrapping pageUrls property
- Add PostListResponse model wrapping posts property
- Update FanboxJsonSerializerContext registrations for new wrapper types
- Update GetCreatorPostPaginationAsync to return response.PageUrls
- Update GetCreatorPostsFromPaginationAsync to return response.Posts
- Update test payloads to match new wrapped JSON response format